### PR TITLE
タブの表示・非表示制御の追加

### DIFF
--- a/src/components/pages/ChatroomPage/Composer.tsx
+++ b/src/components/pages/ChatroomPage/Composer.tsx
@@ -18,8 +18,8 @@ export const CustomComposer = (
         {...props}
         textInputStyle={{
           borderRadius: 12,
-          paddingTop: 8,
           paddingLeft: 12,
+          paddingRight: 12,
           backgroundColor: colors.backgrounds.tertiary,
           color: colors.foregrounds.primary
         }}

--- a/src/components/pages/ChatroomPage/index.tsx
+++ b/src/components/pages/ChatroomPage/index.tsx
@@ -12,6 +12,7 @@ import { CustomDay } from './Day'
 import { useGiftedChatTools } from '../../../services/chat'
 import { useAuthState } from '../../../store/hooks'
 import { GiftedChat } from 'react-native-gifted-chat'
+import SafeAreaView from 'react-native-safe-area-view'
 
 type OwnProps = { roomID: string }
 type Props = OwnProps
@@ -31,35 +32,42 @@ const ChatroomPage = ({ roomID }: Props) => {
   const renderDay = useCallback(props => <CustomDay {...props} />, [])
 
   return (
-    <View style={styles.flex}>
-      <GiftedChat
-        placeholder="Aa"
-        messages={messages}
-        user={{ _id: uid }}
-        alwaysShowSend={true}
-        renderAvatarOnTop={true}
-        showAvatarForEveryMessage={true}
-        isKeyboardInternallyHandled={false}
-        onSend={onSend}
-        onQuickReply={onQuickReply}
-        // onPressActionButton={onPressActionButton}
-        renderBubble={renderBubble}
-        renderAvatar={renderAvatar}
-        renderSend={renderSend}
-        renderInputToolbar={renderInputToolbar}
-        renderComposer={renderComposer}
-        // renderActions={renderActions}
-        renderDay={renderDay}
-      />
+    <SafeAreaView style={styles.container}>
+      <View style={styles.inner}>
+        <GiftedChat
+          placeholder="Aa"
+          messages={messages}
+          user={{ _id: uid }}
+          alwaysShowSend={true}
+          renderAvatarOnTop={true}
+          showAvatarForEveryMessage={true}
+          isKeyboardInternallyHandled={false}
+          onSend={onSend}
+          onQuickReply={onQuickReply}
+          // onPressActionButton={onPressActionButton}
+          renderBubble={renderBubble}
+          renderAvatar={renderAvatar}
+          renderSend={renderSend}
+          renderInputToolbar={renderInputToolbar}
+          renderComposer={renderComposer}
+          // renderActions={renderActions}
+          renderDay={renderDay}
+        />
+      </View>
       <KeyboardSpacer />
-    </View>
+    </SafeAreaView>
   )
 }
 
-const makeStyles: MakeStyles = () =>
+const makeStyles: MakeStyles = colors =>
   StyleSheet.create({
-    flex: {
-      flex: 1
+    container: {
+      flex: 1,
+      backgroundColor: colors.backgrounds.secondary
+    },
+    inner: {
+      flex: 1,
+      backgroundColor: colors.backgrounds.primary
     }
   })
 

--- a/src/navigators/TabNavigator.tsx
+++ b/src/navigators/TabNavigator.tsx
@@ -16,6 +16,14 @@ import {
 import { getTheme } from '../themes'
 import { isIPhoneX, isIPhoneXAbove, X_ABOVE_TAB_NOTCH_HEIGHT } from '../services/design'
 
+const getTabBarVisible = ({ navigation }) => {
+  const { routes } = navigation.state
+  if (routes.length > 1) {
+    return false
+  }
+  return true
+}
+
 const theme = getTheme()
 
 const HomeNavigator = createStackNavigator(
@@ -56,34 +64,46 @@ const TabNavigator = createBottomTabNavigator(
   {
     Home: {
       screen: HomeNavigator,
-      navigationOptions: {
-        tabBarIcon: ({ tintColor, focused }) => {
-          if (isIPhoneX() || isIPhoneXAbove()) {
-            return HomeIcon({ tintColor, focused, inset: [0, 0, X_ABOVE_TAB_NOTCH_HEIGHT, 0] })
-          }
-          return HomeIcon({ tintColor, focused })
+      navigationOptions: ({ navigation }) => {
+        const tabBarVisible = getTabBarVisible({ navigation })
+        return {
+          tabBarIcon: ({ tintColor, focused }) => {
+            if (isIPhoneX() || isIPhoneXAbove()) {
+              return HomeIcon({ tintColor, focused, inset: [0, 0, X_ABOVE_TAB_NOTCH_HEIGHT, 0] })
+            }
+            return HomeIcon({ tintColor, focused })
+          },
+          tabBarVisible
         }
       }
     },
     Post: {
       screen: PostNavigator,
-      navigationOptions: {
-        tabBarIcon: ({ tintColor, focused }) => {
-          if (isIPhoneX() || isIPhoneXAbove()) {
-            return PostIcon({ tintColor, focused, inset: [0, 0, X_ABOVE_TAB_NOTCH_HEIGHT, 0] })
-          }
-          return PostIcon({ tintColor, focused })
+      navigationOptions: ({ navigation }) => {
+        const tabBarVisible = getTabBarVisible({ navigation })
+        return {
+          tabBarIcon: ({ tintColor, focused }) => {
+            if (isIPhoneX() || isIPhoneXAbove()) {
+              return PostIcon({ tintColor, focused, inset: [0, 0, X_ABOVE_TAB_NOTCH_HEIGHT, 0] })
+            }
+            return PostIcon({ tintColor, focused })
+          },
+          tabBarVisible
         }
       }
     },
     User: {
       screen: UserNavigator,
-      navigationOptions: {
-        tabBarIcon: ({ tintColor, focused }) => {
-          if (isIPhoneX() || isIPhoneXAbove()) {
-            return UserIcon({ tintColor, focused, inset: [0, 0, X_ABOVE_TAB_NOTCH_HEIGHT, 0] })
-          }
-          return UserIcon({ tintColor, focused })
+      navigationOptions: ({ navigation }) => {
+        const tabBarVisible = getTabBarVisible({ navigation })
+        return {
+          tabBarIcon: ({ tintColor, focused }) => {
+            if (isIPhoneX() || isIPhoneXAbove()) {
+              return UserIcon({ tintColor, focused, inset: [0, 0, X_ABOVE_TAB_NOTCH_HEIGHT, 0] })
+            }
+            return UserIcon({ tintColor, focused })
+          },
+          tabBarVisible
         }
       }
     }


### PR DESCRIPTION
<img width="584" alt="スクリーンショット 2019-11-28 0 09 16" src="https://user-images.githubusercontent.com/29707568/69735040-5993ef80-1173-11ea-9a88-10473852f646.png">
<img width="584" alt="スクリーンショット 2019-11-28 0 09 23" src="https://user-images.githubusercontent.com/29707568/69735043-5bf64980-1173-11ea-96a6-6957773a0b35.png">

タブナビゲーターの各タブごとに設置しているスタックにおいて、`Main`以外のScreenはタブを非表示にさせるようにしている。