### PR TITLE
ゲストログインのカラー変更

### DIFF
--- a/src/screens/WelcomeScreen.tsx
+++ b/src/screens/WelcomeScreen.tsx
@@ -149,7 +149,7 @@ const makeStyles: MakeStyles = colors =>
       fontSize: 18
     },
     guestText: {
-      color: colors.foregrounds.onTintPrimary,
+      color: colors.foregrounds.primary,
       fontSize: 14
     },
     termText: {


### PR DESCRIPTION
ゲストログインのテキストの色設定が間違っていたので、修正。