### PR TITLE
useGoBackState作成

### DIFF
--- a/src/components/templates/BottomTabLayout.tsx
+++ b/src/components/templates/BottomTabLayout.tsx
@@ -2,21 +2,25 @@ import React from 'react'
 import { StyleSheet, Dimensions, View } from 'react-native'
 import { useSafeArea } from 'react-native-safe-area-context'
 import { useStyles, MakeStyles } from '../../services/design'
+import { useGoBackState } from '../../services/route'
 import { ShadowBase } from '../atoms'
 import { BottomTab } from '../organisms'
 
 const BottomTabLayout: React.FC<{}> = ({ children }) => {
   const inset = useSafeArea()
   const styles = useStyles(makeStyles)
+  const { enabled } = useGoBackState()
 
   return (
     <React.Fragment>
       {children}
-      <View style={[styles.tabContainer, { paddingBottom: inset.bottom }]}>
-        <ShadowBase intensity={2}>
-          <BottomTab fullWidth={true} />
-        </ShadowBase>
-      </View>
+      {!enabled && (
+        <View style={[styles.tabContainer, { paddingBottom: inset.bottom }]}>
+          <ShadowBase intensity={2}>
+            <BottomTab fullWidth={true} />
+          </ShadowBase>
+        </View>
+      )}
     </React.Fragment>
   )
 }

--- a/src/services/route.ts
+++ b/src/services/route.ts
@@ -1,0 +1,28 @@
+import { useState, useCallback, useEffect } from 'react'
+import { useNavigation } from '@react-navigation/core'
+
+export const useGoBackState = () => {
+  const navigation = useNavigation()
+  const [enabled, setEnabled] = useState<boolean>(false)
+
+  const goBack = useCallback(() => {
+    if (!navigation.canGoBack()) return
+    navigation.goBack()
+  }, [navigation])
+
+  useEffect(() => {
+    try {
+      if (navigation.dangerouslyGetState().index === 0) {
+        setEnabled(false)
+        return
+      }
+
+      setEnabled(true)
+    } catch (e) {
+      console.warn(e)
+      setEnabled(false)
+    }
+  }, [navigation])
+
+  return { enabled, goBack }
+}


### PR DESCRIPTION
ヘッダーを、`navigation`のオプションを使って作成するのではなく、スクリーン内で表示の制御をするようにしたい。このhooksを使えば、バックボタンの表示・非表示を判定できるためスクリーン内にヘッダーを設置できるようになるはず...