### PR TITLE
アクション名がかぶらないように修正

### DIFF
--- a/src/store/app/auth/actions.ts
+++ b/src/store/app/auth/actions.ts
@@ -6,8 +6,8 @@ const actionCreator = actionCreateFactory()
 export const appAuthActions = {
   setAuth: actionCreator<string>('SET_AUTH'),
   resetAuth: actionCreator<void>('RESET_AUTH'),
-  setUser: actionCreator<User>('SET_USER'),
-  resetUser: actionCreator<void>('RESET_USER'),
-  startUserSession: actionCreator<string>('START_USER_SESSION'),
-  stopUserSession: actionCreator<void>('STOP_USER_SESSION')
+  setAuthUser: actionCreator<User>('SET_AUTH_USER'),
+  resetAuthUser: actionCreator<void>('RESET_AUTH_USER'),
+  startAuthUserSession: actionCreator<string>('START_AUTH_USER_SESSION'),
+  stopAuthUserSession: actionCreator<void>('STOP_AUTH_USER_SESSION')
 }

--- a/src/store/app/auth/reducer.ts
+++ b/src/store/app/auth/reducer.ts
@@ -23,10 +23,10 @@ export const appAuthReducer = reducerWithInitialState(initialState)
   .case(appAuthActions.resetAuth, state => {
     return { ...state, uid: null, checked: true }
   })
-  .case(appAuthActions.setUser, (state, user) => {
+  .case(appAuthActions.setAuthUser, (state, user) => {
     return { ...state, user }
   })
-  .case(appAuthActions.resetUser, state => {
+  .case(appAuthActions.resetAuthUser, state => {
     return { ...state, user: null }
   })
 

--- a/src/store/app/auth/saga.ts
+++ b/src/store/app/auth/saga.ts
@@ -38,7 +38,7 @@ function* watchAuthChannel() {
 function* handleCatchAuthState(user: firebase.User) {
   try {
     yield put(appAuthActions.setAuth(user.uid))
-    yield put(appAuthActions.startUserSession(user.uid))
+    yield put(appAuthActions.startAuthUserSession(user.uid))
     yield call(askNotificationsPermissionTask, user.uid)
     yield call(updateNotificationsTokenTask, user.uid)
   } catch (e) {
@@ -48,7 +48,7 @@ function* handleCatchAuthState(user: firebase.User) {
 
 function* handleNotCatchAuthState() {
   yield put(appAuthActions.resetAuth())
-  yield put(appAuthActions.stopUserSession())
+  yield put(appAuthActions.stopAuthUserSession())
 }
 
 function* askNotificationsPermissionTask(uid: string) {
@@ -96,9 +96,9 @@ function* updateNotificationsTokenTask(uid: string) {
 // ----------------------------------------
 function* userSessionFlow() {
   while (true) {
-    const { payload: uid } = yield take(appAuthActions.startUserSession)
+    const { payload: uid } = yield take(appAuthActions.startAuthUserSession)
     const task = yield fork(watchUserSessionChannel, uid)
-    yield take(appAuthActions.stopUserSession)
+    yield take(appAuthActions.stopAuthUserSession)
     yield cancel(task)
   }
 }
@@ -147,11 +147,11 @@ function* watchUserSessionChannel(uid: string) {
 }
 
 function* handleCatchUserState(user: User) {
-  yield put(appAuthActions.setUser(user))
+  yield put(appAuthActions.setAuthUser(user))
 }
 
 function* handleNotCatchUserState() {
-  yield put(appAuthActions.resetUser())
+  yield put(appAuthActions.resetAuthUser())
 }
 
 const saga = [watchAuthChannel(), userSessionFlow()]


### PR DESCRIPTION
`domain/user`のアクションと名前がかぶるものがあったため修正。