### PR TITLE
空メッセージの送信をスキップ

### DIFF
--- a/src/navigators/TabNavigator.tsx
+++ b/src/navigators/TabNavigator.tsx
@@ -9,7 +9,6 @@ import {
   SettingScreen,
   TermsScreen,
   PrivacyScreen,
-  ChatScreen,
   RoomScreen,
   SearchUserScreen
 } from '../screens'
@@ -20,7 +19,6 @@ const HomeNavigator = () => (
   <Stack.Navigator initialRouteName="Main">
     <Stack.Screen name="Main" component={HomeScreen} options={{ headerShown: false }} />
     <Stack.Screen name="SwipeCard" component={SwipeCardScreen} options={{ headerShown: false }} />
-    <Stack.Screen name="Chat" component={ChatScreen} options={{ headerShown: false }} />
     <Stack.Screen name="User" component={UserScreen} options={{ headerShown: false }} />
     <Stack.Screen name="UserEdit" component={UserEditScreen} options={{ headerShown: false }} />
     <Stack.Screen name="SearchUser" component={SearchUserScreen} options={{ headerShown: false }} />
@@ -34,7 +32,6 @@ const RoomNavigator = () => (
   <Stack.Navigator initialRouteName="Main">
     <Stack.Screen name="Main" component={RoomScreen} options={{ headerShown: false }} />
     <Stack.Screen name="SwipeCard" component={SwipeCardScreen} options={{ headerShown: false }} />
-    <Stack.Screen name="Chat" component={ChatScreen} options={{ headerShown: false }} />
     <Stack.Screen name="User" component={UserScreen} options={{ headerShown: false }} />
     <Stack.Screen name="UserEdit" component={UserEditScreen} options={{ headerShown: false }} />
     <Stack.Screen name="SearchUser" component={SearchUserScreen} options={{ headerShown: false }} />
@@ -48,7 +45,6 @@ const UserNavigator = () => (
   <Stack.Navigator initialRouteName="Main">
     <Stack.Screen name="Main" component={UserScreen} options={{ headerShown: false }} />
     <Stack.Screen name="SwipeCard" component={SwipeCardScreen} options={{ headerShown: false }} />
-    <Stack.Screen name="Chat" component={ChatScreen} options={{ headerShown: false }} />
     <Stack.Screen name="User" component={UserScreen} options={{ headerShown: false }} />
     <Stack.Screen name="UserEdit" component={UserEditScreen} options={{ headerShown: false }} />
     <Stack.Screen name="SearchUser" component={SearchUserScreen} options={{ headerShown: false }} />

--- a/src/screens/RoomScreen.tsx
+++ b/src/screens/RoomScreen.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useState, useRef, useMemo } from 'react'
 import { View, StyleSheet, TouchableOpacity, Text, Dimensions } from 'react-native'
 import Animated, { Value, Extrapolate, interpolate } from 'react-native-reanimated'
 import { useSafeArea } from 'react-native-safe-area-context'
+import KeyboardSpacer from 'react-native-keyboard-spacer'
 import { useAppAuthState } from '../store/hooks'
 import { useStackNavigation } from '../services/route'
 import { useColors, useStyles, MakeStyles } from '../services/design'
@@ -261,8 +262,17 @@ const RoomScreen = () => {
         <View style={[styles.tabContainer, { paddingBottom: inset.bottom }]}>
           <ShadowBase>
             {isActiveRooms && <BottomTab fullWidth={true} />}
-            {isActiveChat && <ChatInput fullWidth={true} onSend={text => onSend(selectedRoomID, text)} />}
+            {isActiveChat && (
+              <ChatInput
+                fullWidth={true}
+                onSend={text => {
+                  if (text.length === 0) return
+                  onSend(selectedRoomID, text)
+                }}
+              />
+            )}
           </ShadowBase>
+          <KeyboardSpacer />
         </View>
       </View>
     </NormalLayout>


### PR DESCRIPTION
・空メッセージの送信をスキップ
・テキストボックスがキーボードを避けるように
・タブナビゲーターからチャットスクリーンを排除(ルームスクリーンに統合されたため)